### PR TITLE
Fixed angled import in MTPDF.m

### DIFF
--- a/MTPDF.podspec
+++ b/MTPDF.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "MTPDF"
-  s.version      = "0.0.6"
+  s.version      = "0.0.7"
   s.summary      = "Objective-C PDF objects. Doing my part to help us stay out of the headache that is Core Foundation."
-  s.homepage     = "https://github.com/mysterioustrousers/MTPDF"
+  s.homepage     = "https://github.com/OlafAndreas/MTPDF"
   s.license      = 'MIT'
   s.author       = { "Adam Kirk" => "atomkirk@gmail.com" }
-  s.source       = { :git => "https://github.com/mysterioustrousers/MTPDF.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/OlafAndreas/MTPDF.git", :tag => "#{s.version}" }
   s.platform     = :ios, '7.0'
   s.source_files = 'MTPDF/*.{m,h}'
   s.framework    = 'CoreGraphics'

--- a/MTPDF/0.0.7/MTPDF.podspec
+++ b/MTPDF/0.0.7/MTPDF.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "MTPDF"
+  s.version      = "0.0.7"
+  s.summary      = "Objective-C PDF objects. Doing my part to help us stay out of the headache that is Core Foundation."
+  s.homepage     = "https://github.com/OlafAndreas/MTPDF"
+  s.license      = 'MIT'
+  s.author       = { "Adam Kirk" => "atomkirk@gmail.com" }
+  s.source       = { :git => "https://github.com/OlafAndreas/MTPDF.git", :tag => "#{s.version}" }
+  s.platform     = :ios, '7.0'
+  s.source_files = 'MTPDF/*.{m,h}'
+  s.framework    = 'CoreGraphics'
+  s.framework    = 'Foundation'
+  s.framework    = 'UIKit'
+  s.requires_arc = true
+  s.dependency 'MTDates'
+end

--- a/MTPDF/MTPDF.m
+++ b/MTPDF/MTPDF.m
@@ -7,7 +7,7 @@
 //
 
 #import "MTPDF.h"
-#import <NSDate+MTDates.h>
+#import <MTDates/NSDate+MTDates.h>
 
 
 


### PR DESCRIPTION
This resolves an issue when using the `MTPDF` pod in a swift-based project(Not tested with objective-c), where the `#import <NSDate+MTDates.h>` fails due to a `file not found issue`.

This is due to the angled import in `MTPDF.m` which will look for the `NSDate+MTDates.h` in the same scope as the `MTPDF.m` file.

On a comment made by orta(CocoaPods member) on an issue for [CocoaPods](https://github.com/CocoaPods/CocoaPods/issues/3913#issuecomment-128028170)

> In simplified: angled bracket imports are for externals, and should be scoped according to where they come from

Since the `NSDate+MTDates.h` lies within the `MTDates` pod. The import should be prepended with `MTDates/` like this: `#import <MTDates/NSDate+MTDates.h>`